### PR TITLE
Inject languages in filters

### DIFF
--- a/languages/haml/injections.scm
+++ b/languages/haml/injections.scm
@@ -3,3 +3,7 @@
 
 ((ruby_attributes) @content
     (#set! language ruby))
+
+(filter
+   (filter_name) @language
+   (filter_body) @content)


### PR DESCRIPTION
Inject languages in filters. Any named filter
like `javascript` or `css` will be highlighted
with this new injection.

Here are before&after screenshots:

| Before | After |
| ------------- | ------------- |
| ![CleanShot 2024-10-19 at 17 01 27@2x](https://github.com/user-attachments/assets/5db6d980-cf1e-42dd-a14c-3707d7d9af1e) |  ![CleanShot 2024-10-19 at 17 00 51@2x](https://github.com/user-attachments/assets/d131ee9e-d6fa-4435-aa2e-cec488ba55c2)
|![CleanShot 2024-10-19 at 17 04 01@2x](https://github.com/user-attachments/assets/02b6b1c9-44d5-483b-8f3f-b73f4dec6eeb)|![CleanShot 2024-10-19 at 17 04 24@2x](https://github.com/user-attachments/assets/20fdb932-3467-457d-91d6-ef5f77b7fb26)|