### PR TITLE
Add highlight for comments

### DIFF
--- a/languages/haml/highlights.scm
+++ b/languages/haml/highlights.scm
@@ -3,3 +3,4 @@
 (ruby_block_output "=" @keyword)
 (class) @property
 (id) @property
+(comment) @comment


### PR DESCRIPTION
Add highlight for comments so blocks with `-#` and `/` will be highlighted as comments.

Here are before&after screenshots:


| Before      | After |
| ------------- | ------------- |
| ![CleanShot 2024-10-19 at 17 06 35@2x](https://github.com/user-attachments/assets/0f3530c0-16b8-4301-be72-8ba35e41d4db) | ![CleanShot 2024-10-19 at 17 06 42@2x](https://github.com/user-attachments/assets/c4c99819-90a9-44b2-9f56-1c767d3c243c) |
| ![CleanShot 2024-10-19 at 17 09 13@2x](https://github.com/user-attachments/assets/d8774fab-d8a5-4d8f-a837-83fa134804f6)| ![CleanShot 2024-10-19 at 17 08 54@2x](https://github.com/user-attachments/assets/20fe5eed-645b-4e83-83e1-d5fc604fbf96)|