### PR TITLE
Add highlight to strings

### DIFF
--- a/languages/haml/highlights.scm
+++ b/languages/haml/highlights.scm
@@ -3,3 +3,9 @@
 (ruby_block_output "=" @keyword)
 (class) @property
 (id) @property
+
+[
+  (quoted_attribute_value)
+] @string
+
+(text_content) @string


### PR DESCRIPTION
Add highlight to strings which are `text_content` and `quoted_attribute_value` nodes in HAML syntax.

Here are before&after screenshots:


| Before         | After |
| ------------- | ------------- |
| ![CleanShot 2024-10-19 at 17 14 21@2x](https://github.com/user-attachments/assets/3e22ea6d-04ce-4b9e-9423-70e460acde87) | ![CleanShot 2024-10-19 at 17 14 46@2x](https://github.com/user-attachments/assets/d74b3dbf-7774-4ab9-b0d4-7c38145810b8)  |