### PR TITLE
Update tree-sitter grammar

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/davidcornu/zed-haml"
 
 [grammars.haml]
 repository = "https://github.com/vitallium/tree-sitter-haml"
-rev = "945b4806e11d969fc0b0edcdee068400971f3bf3"
+rev = "1d3766b84005009febd5471be561b876f1db503d"


### PR DESCRIPTION
Update tree-sitter grammar for HAML.

The update contains one fix ([upstream issue](https://github.com/vitallium/tree-sitter-haml/issues/5)) to align the parsing of ID and CSS class names with the Ruby implementation of HAML.

Here are before&after screenshots:

|Before|After|
|------|-----|
| ![CleanShot 2024-11-04 at 21 38 29@2x](https://github.com/user-attachments/assets/95fe3a6d-5363-4bf2-8687-98646b57c0a6)|![CleanShot 2024-11-04 at 21 37 05@2x](https://github.com/user-attachments/assets/89eb3043-3559-4636-afb9-ccc5f2641785)|