### PR TITLE
Bump `tree-sitter-haml` to v0.0.5

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/davidcornu/zed-haml"
 
 [grammars.haml]
 repository = "https://github.com/vitallium/tree-sitter-haml"
-rev = "ca002c14a373534affb32079dad6ca4a493451b2"
+rev = "a2af65572be29bb79ef00dd787776b57a82ab16d"


### PR DESCRIPTION
Bump `tree-sitter-haml` to v0.0.5:

- [Allow multiple types of attributes (ruby/html-style) in any order](https://github.com/vitallium/tree-sitter-haml/commit/d6f7256aca9b39fbdbe7b1f0d4a5598e6be27dd2)
- [Add support for ruby variable references in HTML-style attributes](https://github.com/vitallium/tree-sitter-haml/commit/8c8ce9bf4fe617877357e23b2bbeb25354dcb1dc)
- [Use @keyword for HAML ruby control and output statements](https://github.com/vitallium/tree-sitter-haml/commit/cd03764d83380821f81b698aedac0127f07a671d)

Upstream diff: https://github.com/vitallium/tree-sitter-haml/compare/ca002c14a373534affb32079dad6ca4a493451b2..a2af65572be29bb79ef00dd787776b57a82ab16d