### PR TITLE
Change comment symbol to `#-` for silent HAML comments

### DIFF
--- a/languages/haml/config.toml
+++ b/languages/haml/config.toml
@@ -1,6 +1,6 @@
 name = "Haml"
 grammar = "haml"
 path_suffixes = ["haml", "html.haml"]
-line_comments = ["/ "]
+line_comments = ["-# "]
 auto_indent_using_last_non_empty_line = false
 tab_size = 2


### PR DESCRIPTION
This pull request addresses an issue where comments in HAML files were being rendered in the final HTML output. The previous comment symbol, `/`, creates a standard HTML comment (`<!-- -->`), which is visible in the browser's source code.

This change updates the comment symbol to `-#`, which is the HAML syntax for a "silent comment." Silent comments are not rendered in the final HTML output, providing a way to add comments to the HAML source that are not included in the compiled document. This is the expected behavior for developers who want to add notes or disable lines of code without affecting the final output.

[REFERENCE](https://haml.info/docs/yardoc/file.REFERENCE.html#comments)

### HTML Comments: `/`

```haml
%peanutbutterjelly
  / This is the peanutbutterjelly element
  I like sandwiches!
```

is compiled to:

```html
<peanutbutterjelly>
  <!-- This is the peanutbutterjelly element -->
  I like sandwiches!
</peanutbutterjelly>
 ```
 
 ### Haml Comments: `-#`

```haml
%p foo
-# This is a comment
%p bar
```

is compiled to:

```html
<p>foo</p>
<p>bar</p>
```