### PR TITLE
Update HAML grammar to v0.1.0

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/davidcornu/zed-haml"
 
 [grammars.haml]
 repository = "https://github.com/vitallium/tree-sitter-haml"
-rev = "a2af65572be29bb79ef00dd787776b57a82ab16d"
+rev = "3e5bdaef84a7a65bd8e2f8a6f69120b53dac1e94"


### PR DESCRIPTION
Update HAML grammar to [v0.1.0](https://github.com/vitallium/tree-sitter-haml/releases/tag/v0.1.0) that includes the following features and bug fixes:

## Added

1. Implement object reference syntax [] (https://github.com/vitallium/tree-sitter-haml/commit/06fc1d9a110c393386947bfff7bce37040d3f37e)
2. Support additional doctypes (https://github.com/vitallium/tree-sitter-haml/commit/90a6526ca5fe5362191b80b75951a20cfee36165)
3. Allow escaping with backslash (https://github.com/vitallium/tree-sitter-haml/commit/67fb08374f30537a79bea4fa4dbdc6a7b76b38e6)
4. Add whitespace control operators > and < (https://github.com/vitallium/tree-sitter-haml/commit/4064f4b3661f3732c6ceabd25b4634d3d77d5f40)
5. Add Ruby operators &= and ~ (https://github.com/vitallium/tree-sitter-haml/commit/c51ded392a98a60cd5c526a93b25cb1d41b5edd1)
6. Permit empty attribute values (https://github.com/vitallium/tree-sitter-haml/commit/10d9e42cff4621642321d2013376e5ebe6c1c670)
7. Parse Ruby blocks that span multiple lines (https://github.com/vitallium/tree-sitter-haml/commit/31164f12cf1bc44fa73413d771aab440058c5907)

## Fixed

1. Ignore blank lines when tracking indentation (https://github.com/vitallium/tree-sitter-haml/commit/cc264598d7cacc17d20dd4c45afa425c2748384f)
2. Serialize using 16-bit indent values (https://github.com/vitallium/tree-sitter-haml/commit/19ef5fdb9edaa7691d7241468291becad4fda89f)
3. Handle CRLF and CR-only line endings in the scanner (https://github.com/vitallium/tree-sitter-haml/commit/710f899fabe1959701a9c358b6b5717d85e62efa)
4. Improve Ruby interpolation to cope with nested braces (https://github.com/vitallium/tree-sitter-haml/commit/275ae4e2557ac974da4dd820cba3a5faee1dfb76)